### PR TITLE
Fix: Case-sensitivity bug in CSV boolean parsing

### DIFF
--- a/server/src/routes/import-export.routes.ts
+++ b/server/src/routes/import-export.routes.ts
@@ -66,6 +66,17 @@ function escapeCSV(value: any): string {
 }
 
 /**
+ * Helper function to normalize and check CSV truthy values
+ */
+function isCsvTruthy(value: unknown): boolean {
+  const TRUTHY_VALUES = ['true', '1', true, 1];
+  if (typeof value === 'string') {
+    return TRUTHY_VALUES.includes(value.toLowerCase());
+  }
+  return TRUTHY_VALUES.includes(value as any);
+}
+
+/**
  * Helper function to parse CSV line
  */
 function parseCSVLine(line: string): string[] {
@@ -643,8 +654,7 @@ router.post('/import', authMiddleware, async (req: Request, res: Response) => {
             // Create new physical item
             // Parse notes_public - accept 'true', '1', true, or 1 as true values
             const notesPublicValue = movies[0].notes_public;
-            const isNotesPublic = notesPublicValue === 'true' || notesPublicValue === '1' || 
-                                  notesPublicValue === true || notesPublicValue === 1;
+            const isNotesPublic = isCsvTruthy(notesPublicValue);
             
             const physicalItemData = {
               name: itemName,


### PR DESCRIPTION
### Summary
Currently, the application fails to recognize boolean values in CSV imports if they are not strictly lowercase. Many users interact with CSVs in Excel, which defaults to uppercase TRUE. This PR ensures that the CSV-import parsing logic is case-insensitive.

### Changes
- Refactored boolean check into a reusable isCsvTruthy function.
- Added .toLowerCase() normalization for string-based boolean checks.
- Ensured compatibility with string, number, and boolean types to prevent runtime errors.

### Testing
I have verified this fix with the following inputs:
- "TRUE" -> Resolved as true
- "true" -> Resolved as true
- "1" or 1 -> Resolved as true
- "FALSE" or "random" -> Resolved as false