### PR TITLE
Fix: Load dotenv before route imports to ensure env vars are available

### DIFF
--- a/server/src/index-full.ts
+++ b/server/src/index-full.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import dotenv from 'dotenv';
+import 'dotenv/config';
 import path from 'path';
 import { setupDatabase } from './database';
 
@@ -14,9 +14,6 @@ import seriesRoutes from './routes/series.routes';
 import importExportRoutes from './routes/import-export.routes';
 import statisticsRoutes from './routes/statistics.routes';
 import libraryRoutes from './routes/library.routes';
-
-// Load environment variables
-dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -40,11 +37,11 @@ app.get('/api', (req, res) => {
 });
 
 app.get('/api/health', (req, res) => {
-  res.json({ 
+  res.json({
     status: 'healthy',
     mode: 'full',
     timestamp: new Date().toISOString(),
-    version: '1.0.0'
+    version: '1.0.0',
   });
 });
 
@@ -74,6 +71,3 @@ app.listen(PORT, () => {
   console.log(`🎬 Cinefile server running on port ${PORT} (Full Mode)`);
   console.log(`📱 API available at http://localhost:${PORT}/api`);
 });
-
-
-

--- a/server/src/index-readonly.ts
+++ b/server/src/index-readonly.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import dotenv from 'dotenv';
+import 'dotenv/config';
 import path from 'path';
 import rateLimit from 'express-rate-limit';
 import { setupDatabase } from './database';
@@ -13,9 +13,6 @@ import seriesReadOnlyRoutes from './routes/series-readonly.routes';
 import importExportReadOnlyRoutes from './routes/import-export-readonly.routes';
 import statisticsRoutes from './routes/statistics.routes';
 import libraryReadOnlyRoutes from './routes/library-readonly.routes';
-
-// Load environment variables
-dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -33,7 +30,7 @@ const apiLimiter = rateLimit({
 const corsOptions = {
   origin: process.env.ALLOWED_ORIGIN || '*', // Default to * for development, set to your domain in production
   credentials: false,
-  optionsSuccessStatus: 200
+  optionsSuccessStatus: 200,
 };
 
 // Middleware
@@ -46,14 +43,17 @@ setupDatabase();
 
 // Serve uploaded files statically with security options
 const uploadDir = process.env.UPLOAD_DIR || path.join(__dirname, '../uploads');
-app.use('/uploads', express.static(uploadDir, {
-  dotfiles: 'deny', // Deny access to dotfiles
-  index: false, // Disable directory indexing
-  setHeaders: (res, filePath) => {
-    // Set security headers for uploaded files
-    res.set('X-Content-Type-Options', 'nosniff');
-  }
-}));
+app.use(
+  '/uploads',
+  express.static(uploadDir, {
+    dotfiles: 'deny', // Deny access to dotfiles
+    index: false, // Disable directory indexing
+    setHeaders: (res, filePath) => {
+      // Set security headers for uploaded files
+      res.set('X-Content-Type-Options', 'nosniff');
+    },
+  }),
+);
 
 // Apply rate limiting to all API routes
 app.use('/api', apiLimiter);
@@ -64,11 +64,11 @@ app.get('/api', (req, res) => {
 });
 
 app.get('/api/health', (req, res) => {
-  res.json({ 
+  res.json({
     status: 'healthy',
     mode: 'readonly',
     timestamp: new Date().toISOString(),
-    version: '1.0.0'
+    version: '1.0.0',
   });
 });
 
@@ -96,6 +96,3 @@ app.listen(PORT, () => {
   console.log(`🎬 Cinefile server running on port ${PORT} (Read-Only Mode)`);
   console.log(`📱 API available at http://localhost:${PORT}/api`);
 });
-
-
-

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import dotenv from 'dotenv';
+import 'dotenv/config';
 import path from 'path';
 import { setupDatabase } from './database';
 
@@ -15,16 +15,13 @@ import importExportRoutes from './routes/import-export.routes';
 import statisticsRoutes from './routes/statistics.routes';
 import libraryRoutes from './routes/library.routes';
 
-// Load environment variables
-dotenv.config();
-
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 // Middleware
 app.use(cors());
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json({ limit: '50mb' }));
+app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
 // Initialize database
 setupDatabase();
@@ -39,10 +36,10 @@ app.get('/api', (req, res) => {
 });
 
 app.get('/api/health', (req, res) => {
-  res.json({ 
+  res.json({
     status: 'healthy',
     timestamp: new Date().toISOString(),
-    version: '1.0.0'
+    version: '1.0.0',
   });
 });
 


### PR DESCRIPTION
### Summary
`dotenv.config()` was called after route imports in all three server entry points, causing environment variables to always be `undefined` in local development. This fixes the load order so `.env` is populated before any module captures its values.

### Changes
- Replaced `import dotenv from 'dotenv'` & `dotenv.config()` with `import 'dotenv/config'` as a side-effect import in `index.ts`, `index-full.ts`, and `index-readonly.ts`
- Minor fix: aligned express filesize limit in dev (`index`) to enable larger test imports.

### Notes
Only affects local development. Docker deployments inject environment variables directly and are unaffected.