### PR TITLE
Fix: Prevent knex from loading duplicate .ts and .js migrations

### DIFF
--- a/server/knexfile.ts
+++ b/server/knexfile.ts
@@ -7,29 +7,31 @@ const config = {
   development: {
     client: 'better-sqlite3',
     connection: {
-      filename: path.resolve(process.env.DATABASE_PATH || './database.sqlite')
+      filename: path.resolve(process.env.DATABASE_PATH || './database.sqlite'),
     },
     useNullAsDefault: true,
     migrations: {
       directory: './migrations',
-      extension: 'js'
+      extension: 'js',
+      loadExtensions: ['.js'],
     },
     seeds: {
-      directory: './seeds'
-    }
+      directory: './seeds',
+    },
   },
 
   production: {
     client: 'better-sqlite3',
     connection: {
-      filename: path.resolve(process.env.DATABASE_PATH || './database.sqlite')
+      filename: path.resolve(process.env.DATABASE_PATH || './database.sqlite'),
     },
     useNullAsDefault: true,
     migrations: {
       directory: './migrations',
-      extension: 'js'
-    }
-  }
+      extension: 'js',
+      loadExtensions: ['.js'],
+    },
+  },
 };
 
 export default config;

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -6,20 +6,21 @@ const databasePath = process.env.DATABASE_PATH || './database.sqlite';
 export const db = knex({
   client: 'better-sqlite3',
   connection: {
-    filename: path.resolve(databasePath)
+    filename: path.resolve(databasePath),
   },
   useNullAsDefault: true,
   migrations: {
     directory: path.join(__dirname, '../migrations'),
-    extension: 'js'
-  }
+    extension: 'js',
+    loadExtensions: ['.js'],
+  },
 });
 
 export async function setupDatabase() {
   try {
     // Enable foreign keys before running migrations (as a backup)
     await db.raw('PRAGMA foreign_keys = ON');
-    
+
     // Run any pending migrations
     await db.migrate.latest();
     console.log('✅ Database migrations completed');


### PR DESCRIPTION
### Summary
The `migrations/` directory contains both `.ts` and `.js` versions of each migration. When running under `tsx`, Knex loaded both and attempted to run each migration twice, crashing the server on fresh database initialization with `SqliteError: table already exists`.

### Changes
- Added `loadExtensions: ['.js']` to the Knex migration config in `src/database.ts` and `knexfile.ts`

### Notes
- The existing `extension: 'js'` setting only controls the file extension used when generating new migrations via `knex migrate:make` - it does not filter which files are loaded at runtime.
- Validated that the remaining `.ts` files in `migrations/` are not referenced. If there are no future plans involving those files, they may be deleted.

### Testing
Verified by deleting `database.sqlite` and confirming a clean run with `npm run dev` completes migrations without error.